### PR TITLE
Fix isSubmitting formState when encType is application/json for Remix.run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remix-hook-form",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remix-hook-form",
-      "version": "5.1.1",
+      "version": "5.2.0",
       "license": "MIT",
       "workspaces": [
         "src/testing-app",
@@ -42,7 +42,7 @@
         "@remix-run/react": "^2.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-hook-form": "^7.51.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/hook/index.test.tsx
+++ b/src/hook/index.test.tsx
@@ -9,7 +9,6 @@ import {
 import { RemixFormProvider, useRemixForm, useRemixFormContext } from "./index";
 import React from "react";
 import { useFetcher, type Navigation } from "@remix-run/react";
-import { object } from "zod";
 
 const submitMock = vi.fn();
 const fetcherSubmitMock = vi.fn();

--- a/src/hook/index.test.tsx
+++ b/src/hook/index.test.tsx
@@ -9,6 +9,7 @@ import {
 import { RemixFormProvider, useRemixForm, useRemixFormContext } from "./index";
 import React from "react";
 import { useFetcher, type Navigation } from "@remix-run/react";
+import { object } from "zod";
 
 const submitMock = vi.fn();
 const fetcherSubmitMock = vi.fn();
@@ -16,9 +17,10 @@ const fetcherSubmitMock = vi.fn();
 const useActionDataMock = vi.hoisted(() => vi.fn());
 
 const useNavigationMock = vi.hoisted(() =>
-  vi.fn<() => Pick<Navigation, "state" | "formData">>(() => ({
+  vi.fn<() => Pick<Navigation, "state" | "formData" | "json">>(() => ({
     state: "idle",
     formData: undefined,
+    json: undefined,
   })),
 );
 
@@ -249,12 +251,70 @@ describe("useRemixForm", () => {
     useNavigationMock.mockReturnValue({
       state: "submitting",
       formData: new FormData(),
+      json: undefined,
     });
     rerender();
 
     expect(result.current.formState.isSubmitting).toBe(true);
 
-    useNavigationMock.mockReturnValue({ state: "idle", formData: undefined });
+    useNavigationMock.mockReturnValue({
+      state: "idle",
+      formData: undefined,
+      json: undefined,
+    });
+    rerender();
+
+    expect(result.current.formState.isSubmitting).toBe(false);
+  });
+
+  it("should reset isSubmitting when the form is submitted using encType: application/json", async () => {
+    submitMock.mockReset();
+    useNavigationMock.mockClear();
+
+    const { result, rerender } = renderHook(() =>
+      useRemixForm({
+        resolver: () => ({ values: {}, errors: {} }),
+        submitConfig: {
+          action: "/submit",
+          encType: "application/json",
+        },
+      }),
+    );
+
+    expect(result.current.formState.isSubmitting).toBe(false);
+
+    act(() => {
+      result.current.handleSubmit({} as any);
+    });
+    expect(result.current.formState.isSubmitting).toBe(true);
+
+    await waitFor(() => expect(submitMock).toHaveBeenCalledTimes(1));
+
+    expect(result.current.formState.isSubmitting).toBe(true);
+
+    expect(submitMock).toHaveBeenCalledWith(
+      {},
+      {
+        method: "post",
+        action: "/submit",
+        encType: "application/json",
+      },
+    );
+
+    useNavigationMock.mockReturnValue({
+      state: "submitting",
+      formData: undefined,
+      json: {},
+    });
+    rerender();
+
+    expect(result.current.formState.isSubmitting).toBe(true);
+
+    useNavigationMock.mockReturnValue({
+      state: "idle",
+      formData: undefined,
+      json: undefined,
+    });
     rerender();
 
     expect(result.current.formState.isSubmitting).toBe(false);

--- a/src/hook/index.tsx
+++ b/src/hook/index.tsx
@@ -67,14 +67,24 @@ export const useRemixForm = <T extends FieldValues>({
   const methods = useForm<T>({ ...formProps, errors: data?.errors });
   const navigation = useNavigation();
   // Either it's submitted to an action or submitted to a fetcher (or neither)
-  const isSubmittingForm = useMemo(
-    () =>
-      Boolean(
-        (navigation.state !== "idle" && navigation.formData !== undefined) ||
-          (fetcher?.state !== "idle" && fetcher?.formData !== undefined),
-      ),
-    [navigation.state, navigation.formData, fetcher?.state, fetcher?.formData],
-  );
+  const isSubmittingForm = useMemo(() => {
+    const navigationIsSubmitting =
+      navigation.state !== "idle" &&
+      (navigation.formData ?? navigation.json) !== undefined;
+
+    const fetcherIsSubmitting =
+      fetcher?.state !== "idle" &&
+      (fetcher?.formData ?? fetcher?.json) !== undefined;
+
+    return navigationIsSubmitting || fetcherIsSubmitting;
+  }, [
+    navigation.state,
+    navigation.formData,
+    navigation.json,
+    fetcher?.state,
+    fetcher?.formData,
+    fetcher?.json,
+  ]);
 
   // A state to keep track whether we're actually submitting the form through the network
   const [isSubmittingNetwork, setIsSubmittingNetwork] = useState(false);


### PR DESCRIPTION
# Description

This PR fixes a bug where the form isSubmitting state is not tracked properly when using ```encType: 'application/json'```. 
The issue is that the hook only considers navigation / fetcher formData when calculating that a submission is happening. formData is always undefined when using application/json and navigation / fetcher json is populated with the equivalent data. 

Fixes https://github.com/forge-42/remix-hook-form/issues/168

If this is a new feature please add a description of what was added and why below:

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit tests

# Checklist:

- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules